### PR TITLE
Added a button to open release notes of Re:MakePlace itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ For advanced users, the `config.json` file can be manually edited:
   "exe_path": "Makeplace.exe",
   "preserve_folders": ["Makeplace/Custom", "Makeplace/Save"], // Also preserves config.json
   "update_check_url": "https://api.github.com/repos/RemakePlace/app/releases/latest",
+  "release_page_url": "https://github.com/RemakePlace/app/releases/latest",
   "last_check": "2024-01-01T00:00:00Z",
   "auto_check": true,
   "installation_mode": "update"

--- a/ReMakeplaceUpdater/src-tauri/src/config.rs
+++ b/ReMakeplaceUpdater/src-tauri/src/config.rs
@@ -65,7 +65,8 @@ impl ConfigManager {
             installation_path: String::new(),
             exe_path: "Makeplace.exe".to_string(),
             preserve_folders: vec!["Makeplace/Custom".to_string(), "Makeplace/Save".to_string()],
-            update_check_url: "https://api.github.com/repos/RemakePlace/app/releases/latest"
+            update_check_url: "https://api.github.com/repos/RemakePlace/app/releases/latest",
+            release_page_url: "https://github.com/RemakePlace/app/releases/latest"
                 .to_string(),
             last_check: chrono::Utc::now().to_rfc3339(),
             auto_check: true,

--- a/ReMakeplaceUpdater/src-tauri/src/config.rs
+++ b/ReMakeplaceUpdater/src-tauri/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub exe_path: String,
     pub preserve_folders: Vec<String>,
     pub update_check_url: String,
+    pub release_page_url: String,
     pub last_check: String,
     pub auto_check: bool,
     #[serde(default = "default_installation_mode")]
@@ -65,7 +66,8 @@ impl ConfigManager {
             installation_path: String::new(),
             exe_path: "Makeplace.exe".to_string(),
             preserve_folders: vec!["Makeplace/Custom".to_string(), "Makeplace/Save".to_string()],
-            update_check_url: "https://api.github.com/repos/RemakePlace/app/releases/latest",
+            update_check_url: "https://api.github.com/repos/RemakePlace/app/releases/latest"
+                .to_string(),
             release_page_url: "https://github.com/RemakePlace/app/releases/latest"
                 .to_string(),
             last_check: chrono::Utc::now().to_rfc3339(),

--- a/ReMakeplaceUpdater/src/main.ts
+++ b/ReMakeplaceUpdater/src/main.ts
@@ -623,7 +623,7 @@ class ReMakeplaceUpdater {
 
   createReleaseNotesLink() {
     const link = document.createElement("a");
-    link.href = `${this.config?.update_check_url}`;
+    link.href = `${this.config?.release_page_url}`;
     link.textContent = "ⓘ";
     link.target = "_blank";
     link.style.cssText = "color: inherit; text-decoration: none;";

--- a/ReMakeplaceUpdater/src/main.ts
+++ b/ReMakeplaceUpdater/src/main.ts
@@ -628,6 +628,11 @@ class ReMakeplaceUpdater {
     link.onmouseenter = () => link.style.opacity = "0.6";
     link.onmouseleave = () => link.style.opacity = "1";
     link.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="24" style="fill: white;"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>`;
+
+    if (this.releaseNotesElement.children.length > 0){
+      this.releaseNotesElement.innerHTML = "";
+    }
+
     this.releaseNotesElement.appendChild(link);
   }
 

--- a/ReMakeplaceUpdater/src/main.ts
+++ b/ReMakeplaceUpdater/src/main.ts
@@ -622,10 +622,8 @@ class ReMakeplaceUpdater {
   }
 
   createReleaseNotesLink() {
-    if (!this.updateInfo) return;
-
     const link = document.createElement("a");
-    link.href = `https://github.com/RemakePlace/app/releases/tag/${this.updateInfo.latest_version}`;
+    link.href = `${this.config?.update_check_url}`;
     link.textContent = "ⓘ";
     link.target = "_blank";
     link.style.cssText = "color: inherit; text-decoration: none;";

--- a/ReMakeplaceUpdater/src/main.ts
+++ b/ReMakeplaceUpdater/src/main.ts
@@ -624,11 +624,11 @@ class ReMakeplaceUpdater {
   createReleaseNotesLink() {
     const link = document.createElement("a");
     link.href = `${this.config?.release_page_url}`;
-    link.textContent = "ⓘ";
     link.target = "_blank";
-    link.style.cssText = "color: inherit; text-decoration: none;";
+    link.style.cssText = "color: white; text-decoration: none;";
     link.onmouseenter = () => link.style.opacity = "0.6";
     link.onmouseleave = () => link.style.opacity = "1";
+    link.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>`;
     this.releaseNotesElement.appendChild(link);
   }
 

--- a/ReMakeplaceUpdater/src/main.ts
+++ b/ReMakeplaceUpdater/src/main.ts
@@ -625,10 +625,9 @@ class ReMakeplaceUpdater {
     const link = document.createElement("a");
     link.href = `${this.config?.release_page_url}`;
     link.target = "_blank";
-    link.style.cssText = "color: white; text-decoration: none;";
     link.onmouseenter = () => link.style.opacity = "0.6";
     link.onmouseleave = () => link.style.opacity = "1";
-    link.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>`;
+    link.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="24" style="fill: white;"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg>`;
     this.releaseNotesElement.appendChild(link);
   }
 

--- a/ReMakeplaceUpdater/src/main.ts
+++ b/ReMakeplaceUpdater/src/main.ts
@@ -18,6 +18,7 @@ class ReMakeplaceUpdater {
   private statusMessage!: HTMLElement;
   private currentVersionElement!: HTMLElement;
   private latestVersionElement!: HTMLElement;
+  private releaseNotesElement!: HTMLElement;
   private installationPathElement!: HTMLElement;
   private progressBar!: HTMLElement;
   private progressText!: HTMLElement;
@@ -68,7 +69,10 @@ class ReMakeplaceUpdater {
               </div>
               <div class="version-item">
                 <span class="version-label">Latest Version:</span>
-                <span id="latest-version" class="version-text">Checking...</span>
+                <p>
+                  <span id="latest-version" class="version-text">Checking...</span>
+                  <span id="releaseNotes" class="release-notes" title="Link to release notes"></span>
+                </p>
               </div>
             </div>
             <div id="status-message" class="status-message">Initializing...</div>
@@ -182,6 +186,7 @@ class ReMakeplaceUpdater {
     this.statusMessage = document.getElementById("status-message")!;
     this.currentVersionElement = document.getElementById("current-version")!;
     this.latestVersionElement = document.getElementById("latest-version")!;
+    this.releaseNotesElement = document.getElementById("releaseNotes")!;
     this.installationPathElement = document.getElementById("installation-path")!;
     this.progressBar = document.getElementById("progress-bar")!;
     this.progressText = document.getElementById("progress-text")!;
@@ -606,11 +611,27 @@ class ReMakeplaceUpdater {
         this.updateButton.disabled = true;
         this.updateButton.classList.remove("btn-update");
       }
+
+      this.createReleaseNotesLink();
+
     } catch (error) {
       this.setStatus(AppState.ERROR, `Failed to check updates: ${error}`);
       this.updateButton.disabled = false;
       this.updateButton.textContent = "Retry";
     }
+  }
+
+  createReleaseNotesLink() {
+    if (!this.updateInfo) return;
+
+    const link = document.createElement("a");
+    link.href = `https://github.com/RemakePlace/app/releases/tag/${this.updateInfo.latest_version}`;
+    link.textContent = "ⓘ";
+    link.target = "_blank";
+    link.style.cssText = "color: inherit; text-decoration: none;";
+    link.onmouseenter = () => link.style.opacity = "0.6";
+    link.onmouseleave = () => link.style.opacity = "1";
+    this.releaseNotesElement.appendChild(link);
   }
 
   private async startUpdate() {

--- a/ReMakeplaceUpdater/src/style.css
+++ b/ReMakeplaceUpdater/src/style.css
@@ -331,7 +331,7 @@ body {
 }
 
 .release-notes {
-  color: #ff8c42;
+  color: #ffffff;
   font-weight: 700;
   font-size: 18px;
   margin-left: 2px;

--- a/ReMakeplaceUpdater/src/style.css
+++ b/ReMakeplaceUpdater/src/style.css
@@ -330,6 +330,13 @@ body {
   font-size: 18px;
 }
 
+.release-notes {
+  color: #ff8c42;
+  font-weight: 700;
+  font-size: 18px;
+  margin-left: 2px;
+}
+
 /* Status Message */
 .status-message {
   padding: 12px;

--- a/ReMakeplaceUpdater/src/types.ts
+++ b/ReMakeplaceUpdater/src/types.ts
@@ -7,6 +7,7 @@ export interface Config {
   exe_path: string;
   preserve_folders: string[];
   update_check_url: string;
+  release_page_url: string;
   last_check: string;
   auto_check: boolean;
   installation_mode: InstallationMode;


### PR DESCRIPTION
Hi!

Whenever there's a new version available I like checking the release notes, so I thought why not add a button to open that version's release page from the app.

here's a screenshot of the icon in action
<img width="132" height="81" alt="image" src="https://github.com/user-attachments/assets/84ef9582-fef7-49b8-90d8-6b42ec4d2e6a" />


hopefully my code isn't too terrible, I mostly work on backend stuff :)